### PR TITLE
Hardcoded version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.a
 *.gcda
 fatresize
+fatresize_hc

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-PRGNAME     = fatresize
-CC          = /opt/retrostone-toolchain/bin/arm-buildroot-linux-musleabihf-gcc
+PRGNAME     = fatresize_hc
+CC          = /opt/bittboy-toolchain/bin/arm-buildroot-linux-musleabi-gcc
 
 INCLUDES	= -I. -Iinclude
 
-CFLAGS		= -mcpu=cortex-a7 -mfpu=neon -O2 -fsingle-precision-constant -fno-PIC -flto -fno-common -Wall $(INCLUDES)
+CFLAGS		= -O2 -fsingle-precision-constant -fno-PIC -flto -fno-common -Wall $(INCLUDES)
 LDFLAGS     = -Wl,--start-group -lc -lgcc -lm -luuid -lparted -lparted-fs-resize  -flto -Wl,--end-group -s 
 
 # Files to be compiled
 SRCDIR 		=  ./src ./src/fat ./src/hfs
+#SRCDIR 		=  ./src
 VPATH		= $(SRCDIR)
 SRC_C		= $(foreach dir, $(SRCDIR), $(wildcard $(dir)/*.c))
 OBJ_C		= $(notdir $(patsubst %.c, %.o, $(SRC_C)))

--- a/src/fat/fat.c
+++ b/src/fat/fat.c
@@ -24,7 +24,7 @@
 #include "labels/misc.h"
 
 PedFileSystem*
-fat_alloc (const PedGeometry* geom)
+my_fat_alloc (const PedGeometry* geom)
 {
 	PedFileSystem*		fs;
 
@@ -55,7 +55,7 @@ error:
 
 /* Requires the boot sector to be analysed */
 int
-fat_alloc_buffers (PedFileSystem* fs)
+my_fat_alloc_buffers (PedFileSystem* fs)
 {
 	FatSpecific*	fs_info = FAT_SPECIFIC (fs);
 
@@ -77,7 +77,7 @@ error:
 };
 
 void
-fat_free_buffers (PedFileSystem* fs)
+my_fat_free_buffers (PedFileSystem* fs)
 {
 	FatSpecific*	fs_info = FAT_SPECIFIC (fs);
 
@@ -86,7 +86,7 @@ fat_free_buffers (PedFileSystem* fs)
 }
 
 void
-fat_free (PedFileSystem* fs)
+my_fat_free (PedFileSystem* fs)
 {
 	FatSpecific* fs_info = (FatSpecific*) fs->type_specific;
 	free (fs_info->boot_sector);
@@ -163,7 +163,7 @@ fat_open (PedGeometry* geom)
 	PedFileSystem*		fs;
 	FatSpecific*		fs_info;
 
-	fs = fat_alloc (geom);
+	fs = my_fat_alloc (geom);
 	if (!fs)
 		goto error;
 	fs_info = (FatSpecific*) fs->type_specific;
@@ -182,7 +182,7 @@ fat_open (PedGeometry* geom)
 
 	if (!_init_fats (fs))
 		goto error_free_fs;
-	if (!fat_alloc_buffers (fs))
+	if (!my_fat_alloc_buffers (fs))
 		goto error_free_fat_table;
 	if (!fat_collect_cluster_info (fs))
 		goto error_free_buffers;
@@ -190,11 +190,11 @@ fat_open (PedGeometry* geom)
 	return fs;
 
 error_free_buffers:
-	fat_free_buffers (fs);
+	my_fat_free_buffers (fs);
 error_free_fat_table:
 	fat_table_destroy (fs_info->fat);
 error_free_fs:
-	fat_free (fs);
+	my_fat_free (fs);
 error:
 	return NULL;
 }
@@ -216,7 +216,7 @@ fat_create (PedGeometry* geom, FatType fat_type, PedTimer* timer)
 	FatSpecific*		fs_info;
 	FatCluster		table_size;
 
-	fs = fat_alloc (geom);
+	fs = my_fat_alloc (geom);
 	if (!fs)
 		goto error;
 	fs_info = (FatSpecific*) fs->type_specific;
@@ -295,7 +295,7 @@ fat_create (PedGeometry* geom, FatType fat_type, PedTimer* timer)
 	if (!fs_info->fat)
 		goto error_free_fs;
 	fat_table_set_cluster_count (fs_info->fat, fs_info->cluster_count);
-	if (!fat_alloc_buffers (fs))
+	if (!my_fat_alloc_buffers (fs))
 		goto error_free_fat_table;
 
 	if (fs_info->fat_type == FAT_TYPE_FAT32) {
@@ -334,11 +334,11 @@ fat_create (PedGeometry* geom, FatType fat_type, PedTimer* timer)
 	return fs;
 
 error_free_buffers:
-	fat_free_buffers (fs);
+	my_fat_free_buffers (fs);
 error_free_fat_table:
 	fat_table_destroy (fs_info->fat);
 error_free_fs:
-	fat_free (fs);
+	my_fat_free (fs);
 error:
 	return NULL;
 }
@@ -360,9 +360,9 @@ fat_close (PedFileSystem* fs)
 {
 	FatSpecific*	fs_info = FAT_SPECIFIC (fs);
 
-	fat_free_buffers (fs);
+	my_fat_free_buffers (fs);
 	fat_table_destroy (fs_info->fat);
-	fat_free (fs);
+	my_fat_free (fs);
 	return 1;
 }
 

--- a/src/fat/fat.h
+++ b/src/fat/fat.h
@@ -146,10 +146,10 @@ extern PedFileSystemType fat32_type;
 
 extern void fat_print (const PedFileSystem* fs);
 
-extern PedFileSystem* fat_alloc (const PedGeometry* geom);
-extern void fat_free (PedFileSystem* fs);
-extern int fat_alloc_buffers (PedFileSystem* fs);
-extern void fat_free_buffers (PedFileSystem* fs);
+extern PedFileSystem* my_fat_alloc (const PedGeometry* geom);
+extern void my_fat_free (PedFileSystem* fs);
+extern int my_fat_alloc_buffers (PedFileSystem* fs);
+extern void my_fat_free_buffers (PedFileSystem* fs);
 
 extern int fat_resize (PedFileSystem* fs, PedGeometry* geom, PedTimer* timer);
 

--- a/src/fat/resize.c
+++ b/src/fat/resize.c
@@ -658,7 +658,7 @@ create_resize_context (PedFileSystem* fs, const PedGeometry* new_geom)
 				        new_cluster_count))
 		goto error;
 
-	new_fs = fat_alloc (new_geom);
+	new_fs = my_fat_alloc (new_geom);
 	if (!new_fs)
 		goto error;
 
@@ -736,7 +736,7 @@ create_resize_context (PedFileSystem* fs, const PedGeometry* new_geom)
 	if (!fat_op_context_create_initial_fat (context))
 		goto error_free_context;
 
-	if (!fat_alloc_buffers (new_fs))
+	if (!my_fat_alloc_buffers (new_fs))
 		goto error_free_fat;
 
 	return context;
@@ -759,7 +759,7 @@ resize_context_assimilate (FatOpContext* ctx)
 	FatSpecific*	old_fs_info = FAT_SPECIFIC (ctx->old_fs);
 	FatSpecific*	new_fs_info = FAT_SPECIFIC (ctx->new_fs);
 
-	fat_free_buffers (ctx->old_fs);
+	my_fat_free_buffers (ctx->old_fs);
 	fat_table_destroy (old_fs_info->fat);
 	free (old_fs_info);
 	ped_geometry_destroy (ctx->old_fs->geom);
@@ -782,7 +782,7 @@ resize_context_abort (FatOpContext* ctx)
 {
 	FatSpecific*	new_fs_info = FAT_SPECIFIC (ctx->new_fs);
 
-	fat_free_buffers (ctx->new_fs);
+	my_fat_free_buffers (ctx->new_fs);
 	fat_table_destroy (new_fs_info->fat);
 	free (new_fs_info);
 	ped_geometry_destroy (ctx->new_fs->geom);

--- a/src/fatresize.c
+++ b/src/fatresize.c
@@ -1,665 +1,92 @@
-/*
- * $Id: fatresize.c,v 1.9 2005/09/20 08:34:57 siome_tajshe Exp $
- * Copyright (C) 2005-2016  Anton D. Kachalov <mouse@ya.ru>
- *
- * The FAT16/FAT32 non-destructive resizer.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// fatresize_hc
+//
+// public domain code
+// by flabbergast
+//
+// resizes PART partition on DEVICE (hardcoded below) to maximal size
+// (keeping the beginning of pinned)
+// it must be the last partition!
+//
+// TODO: if there is an error, various object may not be deallocated properly
+//
 
-/* activate PED_ASSERT */
-#ifndef DEBUG
-#define DEBUG 1
-#endif
-
-#include <ctype.h>
-#include <errno.h>
-#include <stdio.h>
-#include <getopt.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <inttypes.h>
 #include <parted/parted.h>
-#include <parted/debug.h>
-#include <parted/unit.h>
 
-#include "config.h"
-
-#ifdef LIBPARTED_GT_2_4
-#define FAT_ASSERT(cond, action)		\
-    do {					\
-	if (!(cond)) {				\
-	    PED_ASSERT(cond);			\
-	    action;				\
-	}					\
-    } while (0)
-#else
-#define FAT_ASSERT(cond, action) PED_ASSERT(cond, action)
-#endif
-
-#define FAT32MIN	1024*1024*512
-#define MAX_SIZE_STR	"max"
-
-static struct {
-    unsigned char *dev;
-    unsigned char pnum;
-    PedSector size;
-    char verbose;
-    char progress;
-    char is_evms;
-    char info;
-} opts;
-
-typedef struct {
-    time_t last_update;
-    time_t predicted_time_left;
-} TimerContext;
-
-static TimerContext timer_context;
-
-static void
-usage(int code)
-{
-    fprintf(stdout, "Usage: %s [options] device (e.g. /dev/hda1, /dev/sda2)\n"
-		    "    Resize an FAT16/FAT32 volume non-destructively:\n\n"
-		    "    -s, --size SIZE    Resize volume to SIZE[k|M|G|ki|Mi|Gi] bytes or \""
-		    MAX_SIZE_STR "\"\n"
-		    "    -i, --info         Show volume information\n"
-		    "    -p, --progress     Show progress\n"
-		    "    -q, --quiet        Be quiet\n"
-		    "    -v, --verbose      Verbose\n"
-		    "    -h, --help         Display this help\n\n"
-		    "Please report bugs to %s\n",
-		    PACKAGE_NAME, PACKAGE_BUGREPORT);
-
-    exit(code);
-}
-
-static void
-printd(int level, const char *fmt, ...)
-{
-    va_list ap;
-
-    if (opts.verbose < level)
-	return;
-
-    va_start(ap, fmt);
-    vprintf(fmt, ap);
-    va_end(ap);
-}
-
-static PedSector
-get_size(char *s)
-{
-    PedSector size;
-    char *suffix;
-    int prefix_kind = 1000;
-
-    if (!strncmp(s, MAX_SIZE_STR, sizeof(MAX_SIZE_STR) - 1))
-	return LLONG_MAX;
-
-    size = strtoll(s, &suffix, 10);
-    if (size <= 0 || errno == ERANGE)
-    {
-	fprintf(stderr, "Illegal new volume size\n");
-	usage(1);
-    }
-
-    if (!*suffix)
-	return size;
-
-    if (strlen(suffix) == 2 && suffix[1] == 'i')
-	prefix_kind = 1024;
-    else if (strlen(suffix) > 1)
-	usage(1);
-
-    switch (*suffix)
-    {
-	case 'G':
-	    size *= prefix_kind;
-	case 'M':
-	    size *= prefix_kind;
-	case 'k':
-	    size *= prefix_kind;
-	    break;
-	default:
-	    usage(1);
-    }
-
-    return size;
-}
-
-static int
-get_partnum(char *dev)
-{
-    int pnum;
-    char *p;
-
-    p = dev+strlen(dev)-1;
-    while (*p && isdigit(*p) && *p != '/')
-	p--;
-
-    pnum = atoi(p+1);
-    return pnum ? pnum : 1;
-}
-
-/* Code parts have been taken from _ped_device_probe(). */
-static void
-probe_device(PedDevice **dev, const char *path)
-{
-    ped_exception_fetch_all();
-    *dev = ped_device_get(path);
-    if (!*dev)
-	ped_exception_catch();
-    ped_exception_leave_all();
-}
-
-static char *
-get_devname(char *dev)
-{
-    PedDevice *peddev = NULL;
-    char *devname;
-    char *p;
-
-    p = dev+strlen(dev)-1;
-    while (*p && isdigit(*p) && *p != '/')
-	p--;
-
-    devname = malloc(p-dev+2);
-    strncpy(devname, dev, p-dev+1);
-    devname[p-dev+1] = '\0';
-
-    if (opts.is_evms)
-    {
-	p = strstr(devname, "/evms/");
-	if (p)
-	    strcpy(p, p+5);
-    }
-
-    /* check if the device really exists */
-    while (*p && *p != '/' && !peddev)
-    {
-	devname[p-dev+1] = '\0';
-	probe_device(&peddev, devname);
-	p--;
-    }
-    if (!peddev)
-    {
-	free(devname);
-	return NULL;
-    }
-    ped_device_destroy(peddev);
-
-    return devname;
-}
-
-static void
-resize_handler(PedTimer *timer, void *ctx)
-{
-#if 0
-    int draw_this_time;
-    TimerContext* tctx = (TimerContext*) ctx;
-
-    if (tctx->last_update != timer->now && timer->now > timer->start)
-    {
-	tctx->predicted_time_left = timer->predicted_end - timer->now;
-	tctx->last_update = timer->now;
-	draw_this_time = 1;
-    }
-    else
-	draw_this_time = 0;
-
-    if (draw_this_time)
-    {
-	printf("\r                                                            \r");
-	if (timer->state_name)
-	    printf("%s... ", timer->state_name);
-	printf("%0.f%%\t(time left %.2ld:%.2ld)",
-		100.0 * timer->frac,
-		tctx->predicted_time_left / 60,
-		tctx->predicted_time_left % 60);
-
-	fflush(stdout);
-    }
-#endif
-    fprintf(stdout, ".");
-    fflush(stdout);
-}
-
-static PedExceptionOption
-fatresize_handler(PedException *ex)
-{
-    if (opts.verbose != -1)
-	fprintf(stderr, "%s: %s\n", ped_exception_get_type_string(ex->type),
-				    ex->message);
-
-    if (ex->type >= PED_EXCEPTION_ERROR)
-	return PED_EXCEPTION_CANCEL;
-
-    switch (ex->options)
-    {
-	case PED_EXCEPTION_IGNORE_CANCEL:
-	    return PED_EXCEPTION_IGNORE;
-	default:
-	    return PED_EXCEPTION_UNHANDLED;
-    }
-}
-
-/* This function changes "sector" to "new_sector" if the new value lies
- * within the required range.
- */
-static int
-snap(PedSector* sector, PedSector new_sector, PedGeometry* range)
-{
-    FAT_ASSERT(ped_geometry_test_sector_inside (range, *sector), return 0);
-    if (!ped_geometry_test_sector_inside(range, new_sector))
-	return 0;
-
-    *sector = new_sector;
-    return 1;
-}
-
-/* This function tries to replace the value in sector with a sequence
- * of possible replacements, given in order of preference.  The first
- * replacement that lies within the required range is adopted.
- */
-static void
-try_snap(PedSector* sector, PedGeometry* range, ...)
-{
-    va_list list;
-
-    va_start(list, range);
-    while (1)
-    {
-	PedSector new_sector = va_arg (list, PedSector);
-	if (new_sector == -1)
-	    break;
-	if (snap(sector, new_sector, range))
-	    break;
-    }
-    va_end(list);
-}
-
-/* Snaps a partition to nearby partition boundaries.  This is useful for
- * gobbling up small amounts of free space, and also for reinterpreting small
- * changes to a partition as non-changes (eg: perhaps the user only wanted to
- * resize the end of a partition).
- * 	Note that this isn't the end of the story... this function is
- * always called before the constraint solver kicks in.  So you don't need to
- * worry too much about inadvertantly creating overlapping partitions, etc.
- */
-static void
-snap_to_boundaries (PedGeometry* new_geom, PedGeometry* old_geom,
-		    PedDisk* disk,
-		    PedGeometry* start_range, PedGeometry* end_range)
-{
-	PedPartition*	start_part;
-	PedPartition*	end_part;
-	PedSector	start = new_geom->start;
-	PedSector	end = new_geom->end;
-
-	start_part = ped_disk_get_partition_by_sector (disk, start);
-	end_part = ped_disk_get_partition_by_sector (disk, end);
-	FAT_ASSERT (start_part, return);
-	if (!end_part)
-	    return;
-
-	if (old_geom) {
-		try_snap (&start, start_range,
-			  old_geom->start, start_part->geom.start,
-			  start_part->geom.end + 1, (PedSector)-1);
-		try_snap (&end, end_range,
-			  old_geom->end, end_part->geom.end,
-			  end_part->geom.start - 1, (PedSector)-1);
-	} else {
-		try_snap (&start, start_range,
-			  start_part->geom.start,
-			  start_part->geom.end + 1, (PedSector)-1);
-		try_snap (&end, end_range,
-			  end_part->geom.end,
-			  end_part->geom.start - 1, (PedSector)-1);
-	}
-
-	FAT_ASSERT (start <= end, return);
-	ped_geometry_set (new_geom, start, end - start + 1);
-}
-
-/* This functions constructs a constraint from the following information:
- * 	start, is_start_exact, end, is_end_exact.
- * 	
- * If is_start_exact == 1, then the constraint requires start be as given in
- * "start".  Otherwise, the constraint does not set any requirements on the
- * start.
- */
-static PedConstraint*
-constraint_from_start_end (PedDevice* dev, PedGeometry* range_start,
-                           PedGeometry* range_end)
-{
-    return ped_constraint_new(ped_alignment_any, ped_alignment_any,
-			      range_start, range_end, 1, dev->length);
-}
-
-static PedConstraint*
-constraint_intersect_and_destroy(PedConstraint* a, PedConstraint* b)
-{
-    PedConstraint* result = ped_constraint_intersect(a, b);
-    ped_constraint_destroy(a);
-    ped_constraint_destroy(b);
-    return result;
-}
-
-static int
-partition_warn_busy(PedPartition* part)
-{
-    char* path = ped_partition_get_path(part);
-
-    if (ped_partition_is_busy(part))
-    {
-	ped_exception_throw(PED_EXCEPTION_ERROR, PED_EXCEPTION_CANCEL,
-			("Partition %s is being used.  You must unmount it "
-			 "before you modify it with Parted."),
-			path);
-	free(path);
-	return 0;
-    }
-
-    free(path);
-    return 1;
-}
-
-int
-main(int argc, char **argv)
-{
-    int opt;
-
-    PedDevice *dev;
-    PedDisk *disk;
-    PedPartition *part;
-    PedTimer *timer = NULL;
-
-    char *old_str;
-    char *def_str;
-    PedFileSystem *fs;
-    PedSector start, end;
-    PedGeometry new_geom;
-    PedGeometry *old_geom;
-    PedConstraint *constraint;
-    PedGeometry *range_start, *range_end;
-
-    static const char *sopt = "-his:vpq";
-    static const struct option lopt[] = {
-	{"help",	no_argument,		NULL, 'h'},
-	{"info",	no_argument,		NULL, 'i'},
-	{"progress",	no_argument,		NULL, 'p'},
-	{"size",	required_argument,	NULL, 's'},
-	{"verbose",	no_argument,		NULL, 'v'},
-	{"quiet",	no_argument,		NULL, 'q'},
-	{NULL, 0, NULL, 0}
-    };
-
-    memset(&opts, 0, sizeof(opts));
-
-    if (argc < 2)
-	usage(0);
-
-    while ((opt = getopt_long(argc, argv, sopt, lopt, NULL)) != -1)
-    {
-	switch (opt)
-	{
-	    case 1:
-		if (!opts.dev)
-		{
-		    if (!strncmp(optarg, "/dev/evms/", 10))
-			opts.is_evms = 1;
-		    opts.dev = get_devname(optarg);
-		    opts.pnum = get_partnum(optarg);
-		}
-		else
-		    usage(1);
-		break;
-	    case 'i':
-		opts.info = 1;
-		break;
-	    case 'p':
-		opts.progress = 1;
-		break;
-	    case 's':
-		opts.size = get_size(optarg);
-		break;
-	    case 'v':
-		opts.verbose++;
-		break;
-	    case 'q':
-		opts.verbose = -1;
-		break;
-	    case 'h':
-	    case '?':
-	    default:
-		printd(0, "%s (%s)\n", PACKAGE_STRING, BUILD_DATE);
-		usage(0);
-	}
-    }
-
-    printd(0, "%s (%s)\n", PACKAGE_STRING, BUILD_DATE);
-
-    if (!opts.dev)
-    {
-	fprintf(stderr, "You must specify exactly one existing device.\n");
-	return 1;
-    }
-    else if (!opts.size && !opts.info)
-    {
-	fprintf(stderr, "You must specify new size.\n");
-	return 1;
-    }
-
-    ped_exception_set_handler(fatresize_handler);
-
-    if (opts.progress)
-    {
-	timer = ped_timer_new(resize_handler, &timer_context);
-	timer_context.last_update = 0;
-    }
-
-    printd(3, "ped_device_get(%s)\n", opts.dev);
-    dev = ped_device_get(opts.dev);
-    if (!dev)
-	return 1;
-
-    printd(3, "ped_device_open()\n");
-    if (!ped_device_open(dev))
-	return 1;
-
-    printd(3, "ped_disk_new()\n");
-    disk = ped_disk_new(dev);
-    if (!disk)
-	return 1;
-
-    printd(3, "ped_disk_get_partition(%d)\n", opts.pnum);
-    part = ped_disk_get_partition(disk, opts.pnum);
-    if (!part || !part->fs_type)
-	return 1;
-
-    if (strncmp(part->fs_type->name, "fat", 3))
-    {
-#if 0
-	if (opts.is_evms)
-	{
-	    ped_exception_throw(PED_EXCEPTION_ERROR, PED_EXCEPTION_CANCEL,
-				"%s is not valid FAT16/FAT32 partition.",
-				opts.dev);
-	}
-	else
-#endif
-	{
-	    ped_exception_throw(PED_EXCEPTION_ERROR, PED_EXCEPTION_CANCEL,
-				"%s%d is not valid FAT16/FAT32 partition.",
-				opts.dev, opts.pnum);
-	}
-	return 1;
-    }
-
-    if (!partition_warn_busy(part))
-    {
-	ped_disk_destroy(disk);
-	return 1;
-    }
-
-    if (opts.info || opts.size == LLONG_MAX)
-    {
-	printd(3, "ped_file_system_open()\n");
-	fs = ped_file_system_open(&part->geom);
-	if (!fs)
-	    return 1;
-
-	printd(3, "ped_file_system_get_resize_constraint()\n");
-	constraint = ped_file_system_get_resize_constraint(fs);
-	if (!constraint)
-	    return 1;
-    }
-    if (opts.info)
-    {
-	printf("FAT: %s\n", part->fs_type->name);
-	printf("Size: %llu\n", fs->geom->length * dev->sector_size);
-	printf("Min size: %llu\n", (part->fs_type->name[3] == '3'
-		&& (constraint->min_size * dev->sector_size) < FAT32MIN ?
-			FAT32MIN : constraint->min_size * dev->sector_size));
-	printf("Max size: %llu\n", constraint->max_size * dev->sector_size);
-
-	ped_constraint_destroy(constraint);
-	return 0;
-    }
-    if (opts.size == LLONG_MAX)
-    {
-	opts.size = constraint->max_size * dev->sector_size;
-	ped_constraint_destroy(constraint);
-    }
-
-    start = part->geom.start;
-    printd(3, "ped_geometry_new(%llu)\n", start);
-    range_start = ped_geometry_new (dev, start, 1);
-    if (!range_start)
-	return 1;
-
-    end = part->geom.start + opts.size / dev->sector_size;
-    printd(3, "ped_unit_parse(%llu)\n", end);
-    old_str = ped_unit_format(dev, part->geom.end);
-    def_str = ped_unit_format(dev, end);
-    if (!strcmp(old_str, def_str))
-    {
-	range_end = ped_geometry_new(dev, part->geom.end, 1);
-	if (!range_end)
-	    return 1;
-    }
-    else if (!ped_unit_parse(def_str, dev, &end, &range_end))
-	return 1;
-    free(old_str);
-    free(def_str);
-
-    printd(3, "ped_geometry_duplicate()\n");
-    old_geom = ped_geometry_duplicate(&part->geom);
-    if (!old_geom)
-	return 1;
-
-    printd(3, "ped_geometry_init(%llu, %llu)\n", start, end - start + 1);
-    if (!ped_geometry_init(&new_geom, dev, start, end - start + 1))
-	return 1;
-
-    printd(3, "snap_to_boundaries()\n");
-    snap_to_boundaries(&new_geom, &part->geom, disk, range_start, range_end);
-
-    printd(3, "ped_file_system_open()\n");
-    fs = ped_file_system_open(&part->geom);
-    if (!fs)
-	return 1;
-
-    printd(3, "constraint_intersect_and_destroy()\n");
-    constraint = constraint_intersect_and_destroy(
-		    ped_file_system_get_resize_constraint(fs),
-		    constraint_from_start_end(dev, range_start, range_end)
-		    );
-    if (!constraint)
+#define DEVICE "/dev/mmcblk0"
+#define PART 4
+
+#define err(f_, ...) fprintf(stderr, ("fatresize_hc error: "f_"\n"), ##__VA_ARGS__)
+#define msg(f_, ...) fprintf(stdout, ("fatresize_hc: "f_"\n"), ##__VA_ARGS__)
+
+int main(void) {
+    PedDevice *dev = NULL;
+    PedDisk *disk = NULL;
+    PedPartition *part = NULL;
+    PedFileSystem *fs = NULL;
+    PedGeometry *new_geom = NULL;
+    PedConstraint *constraint = NULL;
+
+    if(!(dev = ped_device_get(DEVICE))) {
+        err("Could not find device "DEVICE);
         return 1;
-
-    /* FAT32 must be bigger than 512Mb */
-    if (part->fs_type->name[3] == '3' && opts.size < FAT32MIN)
-    {
-	ped_exception_throw(PED_EXCEPTION_ERROR, PED_EXCEPTION_CANCEL,
-			    "FAT32 partition must be bigger than 512Mb.");
-	return 1;
     }
 
-    /* Resize partition */
-    printd(3, "ped_disk_set_partition_geom(%llu, %llu)\n", new_geom.start, new_geom.end);
-    if (!ped_disk_set_partition_geom(disk, part, constraint,
-				     new_geom.start, new_geom.end))
-    {
-	ped_file_system_close(fs);
-	ped_constraint_destroy(constraint);
-	return 1;
-    }
-
-    printd(1, "Resizing file system.\n");
-    if (!ped_file_system_resize(fs, &part->geom, timer))
+    if(!ped_device_open(dev)) {
+        err("Could not open device "DEVICE);
         return 1;
+    }
 
-    printd(1, "Done.\n");
-    /* May have changed... fat16 -> fat32 */
-    ped_partition_set_system(part, fs->type);
-    ped_file_system_close(fs);
+    if(!(disk = ped_disk_new(dev))) {
+        err("Could not read partition table of "DEVICE);
+        return 1;
+    }
+
+    if(!(part = ped_disk_get_partition(disk, PART))) {
+        err("Could not open partition %d of "DEVICE, PART);
+        return 1;
+    }
+
+    if(!(fs = ped_file_system_open(&part->geom))) {
+        err("Could not open filesystem");
+        return 1;
+    }
+
+    if(!(constraint = ped_file_system_get_resize_constraint(fs))) {
+        err("Could not get resize constraint");
+        return 1;
+    }
+
+    new_geom = ped_geometry_new(dev, (part->geom).start, constraint->max_size - (part->geom).start);
+
+    msg("old: start %llu, end %llu\n", (part->geom).start, (part->geom).end);
+    msg("new: start %llu, end %llu\n", new_geom->start, new_geom->end);
+
+    // resize partititon
+    msg("resizing partition...");
+    if(!ped_disk_set_partition_geom(disk, part, ped_constraint_exact(new_geom), new_geom->start, new_geom->end)) {
+        err("Could not resize partition");
+        return 1;
+    }
+
+    // resize filesystem
+    msg("resizing filesystem...");
+    if(!ped_file_system_resize(fs, new_geom, NULL)) {
+        err("Could not resize filesystem");
+        return 1;
+    }
+
+    // commit
+    msg("committing changes...");
+    if(!ped_disk_commit(disk)) {
+        err("Could not commit changes!");
+        return 1;
+    }
+
     ped_constraint_destroy(constraint);
-
-    if (!opts.is_evms)
-    {
-	printd(1, "Committing changes.\n");
-	if (!ped_disk_commit(disk))
-	    return 1;
-    }
-    else
-    {
-	printd(3, "ped_constraint_exact()\n");
-	constraint = ped_constraint_exact(old_geom);
-	if (!constraint)
-	    return 1;
-
-	printd(3, "ped_disk_set_partition_geom(%llu, %llu)\n", old_geom->start, old_geom->end);
-	if (!ped_disk_set_partition_geom(disk, part, constraint,
-					 old_geom->start, old_geom->end))
-	{
-	    ped_constraint_destroy(constraint);
-	    return 1;
-	}
-	ped_constraint_destroy(constraint);
-
-	printd(1, "Commiting changes only to disk.\n");
-	if (!ped_disk_commit_to_dev(disk))
-	    return 1;
-    }
+    ped_geometry_destroy(new_geom);
+    ped_file_system_close(fs);
     ped_disk_destroy(disk);
-
-    if (dev->boot_dirty && dev->type != PED_DEVICE_FILE)
-    {
-	ped_exception_throw(PED_EXCEPTION_WARNING, PED_EXCEPTION_OK,
-		 ("You should reinstall your boot loader."
-		  "Read section 4 of the Parted User "
-		  "documentation for more information."));
-    }
-
     ped_device_close(dev);
-
+    msg("done.");
     return 0;
 }

--- a/src/hfs/hfs.c
+++ b/src/hfs/hfs.c
@@ -39,10 +39,10 @@
 #include "hfs.h"
 #include "probe.h"
 
-uint8_t* hfs_block = NULL;
-uint8_t* hfsp_block = NULL;
-unsigned hfs_block_count;
-unsigned hfsp_block_count;
+uint8_t* my_hfs_block = NULL;
+uint8_t* my_hfsp_block = NULL;
+unsigned my_hfs_block_count;
+unsigned my_hfsp_block_count;
 
 #define HFS_BLOCK_SIZES       ((int[2]){512, 0})
 #define HFSP_BLOCK_SIZES       ((int[2]){512, 0})
@@ -87,7 +87,7 @@ hfs_open (PedGeometry* geom)
 	HfsMasterDirectoryBlock* mdb;
 	HfsPrivateFSData* 	priv_data;
 
-	if (!hfsc_can_use_geom (geom))
+	if (!my_hfsc_can_use_geom (geom))
 		return NULL;
 
 	/* Read MDB */
@@ -409,7 +409,7 @@ hfsplus_open (PedGeometry* geom)
 	PedGeometry*		wrapper_geom;
 	unsigned int		map_sectors;
 
-	if (!hfsc_can_use_geom (geom))
+	if (!my_hfsc_can_use_geom (geom))
 		return NULL;
 
 	fs = (PedFileSystem*) ped_malloc (sizeof (PedFileSystem));
@@ -784,23 +784,23 @@ hfsplus_wrapper_update (PedFileSystem* fs)
 			PED_BE32_TO_CPU (priv_data->vh->total_blocks)
 			* ( PED_BE32_TO_CPU (priv_data->vh->block_size)
 			    / PED_SECTOR_SIZE_DEFAULT );
-	unsigned int		hfs_blocks_embedded =
+	unsigned int		my_hfs_blocks_embedded =
 				    (hfsplus_sect + hfs_sect_block - 1)
 				    / hfs_sect_block;
-	unsigned int		hfs_blocks_embedded_old;
+	unsigned int		my_hfs_blocks_embedded_old;
 
 	/* update HFS wrapper MDB */
-	hfs_blocks_embedded_old = PED_BE16_TO_CPU (
+	my_hfs_blocks_embedded_old = PED_BE16_TO_CPU (
 					hfs_priv_data->mdb->old_new
 					.embedded.location.block_count );
 	hfs_priv_data->mdb->old_new.embedded.location.block_count =
-		PED_CPU_TO_BE16 (hfs_blocks_embedded);
+		PED_CPU_TO_BE16 (my_hfs_blocks_embedded);
 	/* maybe macOS will boot with this */
 	/* update : yes it does \o/ :) */
 	hfs_priv_data->mdb->free_blocks =
 	    PED_CPU_TO_BE16 ( PED_BE16_TO_CPU (hfs_priv_data->mdb->free_blocks)
-	                    + hfs_blocks_embedded_old
-			    - hfs_blocks_embedded );
+	                    + my_hfs_blocks_embedded_old
+			    - my_hfs_blocks_embedded );
 
 	if (!hfs_update_mdb(priv_data->wrapper))
 		return 0;
@@ -817,11 +817,11 @@ hfsplus_wrapper_update (PedFileSystem* fs)
 	for (i = PED_BE16_TO_CPU (
 			hfs_priv_data->mdb->old_new.embedded
 			.location.start_block )
-		 + hfs_blocks_embedded;
+		 + my_hfs_blocks_embedded;
 	     i < PED_BE16_TO_CPU (
 	    		hfs_priv_data->mdb->old_new.embedded
 			.location.start_block )
-		 + hfs_blocks_embedded_old;
+		 + my_hfs_blocks_embedded_old;
 	     i++ ) {
 		CLR_BLOC_OCCUPATION(hfs_priv_data->alloc_map, i);
 	}

--- a/src/hfs/hfs.h
+++ b/src/hfs/hfs.h
@@ -639,9 +639,9 @@ struct _HfsCPrivateLeafRec {
 };
 typedef struct _HfsCPrivateLeafRec HfsCPrivateLeafRec;
 
-extern uint8_t*    hfs_block;
-extern uint8_t*    hfsp_block;
-extern unsigned    hfs_block_count;
-extern unsigned    hfsp_block_count;
+extern uint8_t*    my_hfs_block;
+extern uint8_t*    my_hfsp_block;
+extern unsigned    my_hfs_block_count;
+extern unsigned    my_hfsp_block_count;
 
 #endif /* _HFS_H */

--- a/src/hfs/probe.c
+++ b/src/hfs/probe.c
@@ -35,7 +35,7 @@
 #include "probe.h"
 
 int
-hfsc_can_use_geom (PedGeometry* geom)
+my_hfsc_can_use_geom (PedGeometry* geom)
 {
 	PedDevice* dev;
 

--- a/src/hfs/probe.h
+++ b/src/hfs/probe.h
@@ -26,7 +26,7 @@
 #include "hfs.h"
 
 int
-hfsc_can_use_geom (PedGeometry* geom);
+my_hfsc_can_use_geom (PedGeometry* geom);
 
 PedGeometry*
 hfs_and_wrapper_probe (PedGeometry* geom);

--- a/src/hfs/reloc.c
+++ b/src/hfs/reloc.c
@@ -52,7 +52,7 @@ hfs_effect_move_extent (PedFileSystem *fs, unsigned int *ptr_fblock,
 	unsigned int		next_to_fblock;
 	unsigned int		start, stop;
 
-	PED_ASSERT (hfs_block != NULL);
+	PED_ASSERT (my_hfs_block != NULL);
 	PED_ASSERT (*ptr_to_fblock <= *ptr_fblock);
 	/* quiet gcc */
 	start = stop = 0;
@@ -112,18 +112,18 @@ hfs_effect_move_extent (PedFileSystem *fs, unsigned int *ptr_fblock,
 			PedSector 	abs_sector;
 			unsigned int	ai;
 
-			j = size - i; j = (j < hfs_block_count) ?
-					   j : hfs_block_count ;
+			j = size - i; j = (j < my_hfs_block_count) ?
+					   j : my_hfs_block_count ;
 
 			abs_sector = start_block
 				     + (PedSector) (*ptr_fblock + i) * block_sz;
-			if (!ped_geometry_read (fs->geom, hfs_block, abs_sector,
+			if (!ped_geometry_read (fs->geom, my_hfs_block, abs_sector,
 						block_sz * j))
 				return -1;
 
 			abs_sector = start_block
 				     + (PedSector) (start + i) * block_sz;
-			if (!ped_geometry_write (fs->geom,hfs_block,abs_sector,
+			if (!ped_geometry_write (fs->geom,my_hfs_block,abs_sector,
 						 block_sz * j))
 				return -1;
 
@@ -595,7 +595,7 @@ hfs_pack_free_space_from_block (PedFileSystem *fs, unsigned int fblock,
 				          + 1 - start - to_free;
 	int			ret;
 
-	PED_ASSERT (!hfs_block);
+	PED_ASSERT (!my_hfs_block);
 
 	cache = hfs_cache_extents (fs, timer);
 	if (!cache)
@@ -609,21 +609,21 @@ hfs_pack_free_space_from_block (PedFileSystem *fs, unsigned int fblock,
 	bytes_buff = PED_BE32_TO_CPU (priv_data->mdb->block_size)
 		     * (PedSector) BLOCK_MAX_BUFF;
 	if (bytes_buff > BYTES_MAX_BUFF) {
-		hfs_block_count = BYTES_MAX_BUFF
+		my_hfs_block_count = BYTES_MAX_BUFF
 				 / PED_BE32_TO_CPU (priv_data->mdb->block_size);
-		if (!hfs_block_count)
-			hfs_block_count = 1;
-		bytes_buff = (PedSector) hfs_block_count
+		if (!my_hfs_block_count)
+			my_hfs_block_count = 1;
+		bytes_buff = (PedSector) my_hfs_block_count
 			     * PED_BE32_TO_CPU (priv_data->mdb->block_size);
 	} else
-		hfs_block_count = BLOCK_MAX_BUFF;
+		my_hfs_block_count = BLOCK_MAX_BUFF;
 
 	/* If the cache code requests more space, give it to him */
 	if (bytes_buff < hfsc_cache_needed_buffer (cache))
 		bytes_buff = hfsc_cache_needed_buffer (cache);
 
-	hfs_block = (uint8_t*) ped_malloc (bytes_buff);
-	if (!hfs_block)
+	my_hfs_block = (uint8_t*) ped_malloc (bytes_buff);
+	if (!my_hfs_block)
 		goto error_cache;
 
 	if (!hfs_read_bad_blocks (fs)) {
@@ -655,12 +655,12 @@ hfs_pack_free_space_from_block (PedFileSystem *fs, unsigned int fblock,
 		ped_timer_update(timer, (float)(to_fblock - start)/divisor);
 	}
 
-	free (hfs_block); hfs_block = NULL; hfs_block_count = 0;
+	free (my_hfs_block); my_hfs_block = NULL; my_hfs_block_count = 0;
 	hfsc_delete_cache (cache);
 	return 1;
 
 error_alloc:
-	free (hfs_block); hfs_block = NULL; hfs_block_count = 0;
+	free (my_hfs_block); my_hfs_block = NULL; my_hfs_block_count = 0;
 error_cache:
 	hfsc_delete_cache (cache);
 	return 0;


### PR DESCRIPTION
Fix static linking conflicts by renaming some functions in src/{fat,hfs}.

Replace the original fatresize.c by a minimal hardcoded example.